### PR TITLE
Fix windows paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,9 @@ build/
 !handouts/imgs/*.pdf
 
 # Vscode related
-.vscode
+.vscode/*
+# but handy to create a task to launch VS dev terminal in VSCode
+!.vscode/tasks.json
 
 # Generated code
 __pycache__/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// Usage: ctrl + shift + p -> choose Tasks: Run Task, the first one should be
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Open VS Developer Command Prompt",
+            "type": "shell",
+            "command": "cmd",
+            "args": [
+                "/k",
+                "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\Tools\\VsDevCmd.bat",
+                "-arch=x64",
+                "-host_arch=x64"
+            ],
+            "problemMatcher": [],
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,7 @@
             "args": [
                 "/k",
                 "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\Tools\\VsDevCmd.bat",
-                "-arch=x64",
+                "-arch=x64",  // these 2 are very important, otherwise it generates 32-bit lib and fails compile
                 "-host_arch=x64"
             ],
             "problemMatcher": [],

--- a/compiler.py
+++ b/compiler.py
@@ -71,12 +71,12 @@ def topo_sort_structs(structs : dict[str, loma_ir.Struct]):
 1. General programming bug: output_filename : str = None 
     will cause a bug if we don't specify its value (though we never).
     It's better to have some concrete default value (e.g. gcc use a.out)
-2. Windows path: it's crucial to distinguish what suffix -- [.o, .dll, etc.] to apppend
+2. Windows path: it's better to distinguish what suffix -- [.o, .dll, etc.] to apppend
     to {output_filename}, which doesn't have a suffix.
     The original code at "# + .dll or + .so" messed up this suffix-free {output_filename}
-    and thus failed later operations:
-    it fails to compile on Windows, because we created something like sum_array.dll.o
-    it works imperfectly on Linux, the lib is sum_array.so.so instead of sum_array.so
+    and thus messed up filenames we generate:
+    on Windows, we created something like sum_array.so.dll
+    on Linux, the lib is sum_array.so.so instead of sum_array.so
     We will just create different var for these strings to better clearify things.
     Use sum_array as example, we are likely to have these under _code/ on Windows
     - sum_array.dll

--- a/compiler.py
+++ b/compiler.py
@@ -83,6 +83,10 @@ def topo_sort_structs(structs : dict[str, loma_ir.Struct]):
     - sum_array.exp
     - sum_array.lib
     - sum_array.o
+
+FIXED & TESTED: c backend, Windows and Linux(Ubuntu)
+FIXED (but probably work): ispc
+cl_compile() hasn't been fixed
 """
 def compile(loma_code : str,
             target : str = 'c',
@@ -105,10 +109,6 @@ def compile(loma_code : str,
         opencl_context, opencl_device, opencl_command_queue - see cl_utils.create_context()
                     only used by the opencl backend
         print_error - whether it prints compile errors or not
-
-    FIXED & TESTED: c backend, Windows and Linux(Ubuntu)
-    FIXED (but probably work): ispc
-    cl_compile() hasn't been fixed
     """
 
     # The compiler passes

--- a/compiler.py
+++ b/compiler.py
@@ -66,9 +66,27 @@ def topo_sort_structs(structs : dict[str, loma_ir.Struct]):
         traverse_structs(s)
     return sorted_structs_list
 
+
+"""UPDATE LOG:
+1. General programming bug: output_filename : str = None 
+    will cause a bug if we don't specify its value (though we never).
+    It's better to have some concrete default value (e.g. gcc use a.out)
+2. Windows path: it's crucial to distinguish what suffix -- [.o, .dll, etc.] to apppend
+    to {output_filename}, which doesn't have a suffix.
+    The original code at "# + .dll or + .so" messed up this suffix-free {output_filename}
+    and thus failed later operations:
+    it fails to compile on Windows, because we created something like sum_array.dll.o
+    it works imperfectly on Linux, the lib is sum_array.so.so instead of sum_array.so
+    We will just create different var for these strings to better clearify things.
+    Use sum_array as example, we are likely to have these under _code/ on Windows
+    - sum_array.dll
+    - sum_array.exp
+    - sum_array.lib
+    - sum_array.o
+"""
 def compile(loma_code : str,
             target : str = 'c',
-            output_filename : str = None,
+            output_filename : str = "_code/app",
             opencl_context = None,
             opencl_device = None,
             opencl_command_queue = None,
@@ -115,8 +133,12 @@ def compile(loma_code : str,
 
     if output_filename is not None:
         # + .dll or + .so
-        output_filename = output_filename + distutils.ccompiler.new_compiler().shared_lib_extension
+        # output_filename = output_filename + distutils.ccompiler.new_compiler().shared_lib_extension
         pathlib.Path(os.path.dirname(output_filename)).mkdir(parents=True, exist_ok=True)
+
+    # build different filenames
+    obj_filename = output_filename + '.o'
+    lib_filename = output_filename + distutils.ccompiler.new_compiler().shared_lib_extension # .so for Linux; .dll for Windows
 
     # Generate and compile the code
     if target == 'c':
@@ -133,14 +155,15 @@ def compile(loma_code : str,
             tmp_c_filename = f'_tmp.c'
             with open(tmp_c_filename, 'w') as f:
                 f.write(code)
-            obj_filename = output_filename + '.o'
+            # compile without linking
             log = run(['cl.exe', '/c', '/O2', f'/Fo:{obj_filename}', tmp_c_filename],
                 encoding='utf-8',
                 capture_output=True)
             if log.returncode != 0:
                 print(log.stderr)
             exports = [f'/EXPORT:{f.id}' for f in funcs.values()]
-            log = run(['link.exe', '/DLL', f'/OUT:{output_filename}', '/OPT:REF', '/OPT:ICF', *exports, obj_filename],
+            # linking
+            log = run(['link.exe', '/DLL', f'/OUT:{lib_filename}', '/OPT:REF', '/OPT:ICF', *exports, obj_filename],
                 encoding='utf-8',
                 capture_output=True)
             if log.returncode != 0:
@@ -170,7 +193,6 @@ void atomic_add(float *ptr, float val) {
         print('Generated ISPC code:')
         print(code)
 
-        obj_filename = output_filename + '.o'
         log = run(['ispc', '--pic', '-o', obj_filename, '-O2', '-'],
             input = code,
             encoding='utf-8',
@@ -192,7 +214,7 @@ void atomic_add(float *ptr, float val) {
             if log.returncode != 0:
                 print(log.stderr)
             exports = [f'/EXPORT:{f.id}' for f in funcs.values()]
-            log = run(['link.exe', '/DLL', f'/OUT:{output_filename}', '/OPT:REF', '/OPT:ICF', *exports, obj_filename, tasksys_obj_path],
+            log = run(['link.exe', '/DLL', f'/OUT:{lib_filename}', '/OPT:REF', '/OPT:ICF', *exports, obj_filename, tasksys_obj_path],
                 encoding='utf-8',
                 capture_output=True)
             if log.returncode != 0:
@@ -257,7 +279,7 @@ static float cl_atomic_add(volatile __global float *p, float val) {
 
     # load the dynamic library
     if target == 'c' or target == 'ispc':
-        lib = CDLL(os.path.join(os.getcwd(), output_filename))
+        lib = CDLL(os.path.join(os.getcwd(), lib_filename))
         for f in funcs.values():
             if target == 'ispc':
                 # only process SIMD functions

--- a/examples/mass_spring_rev.py
+++ b/examples/mass_spring_rev.py
@@ -12,7 +12,7 @@ import numpy as np
 with open('loma_code/mass_spring_rev.py') as f:
     structs, lib = compiler.compile(f.read(),
                               target = 'c',
-                              output_filename = '_code/mass_spring_rev.so')
+                              output_filename = '_code/mass_spring_rev')
 gradH = lib.gradH
 MassSpringConfig = structs['MassSpringConfig']
 

--- a/examples/optimize_poly_fwd.py
+++ b/examples/optimize_poly_fwd.py
@@ -11,7 +11,7 @@ import ctypes
 with open('loma_code/third_order_poly_fwd.py') as f:
     _, lib = compiler.compile(f.read(),
                               target = 'c',
-                              output_filename = '_code/third_order_poly_fwd.so')
+                              output_filename = '_code/third_order_poly_fwd')
 
 f = lib.third_order_poly
 grad_f = lib.grad_third_order_poly

--- a/examples/optimize_poly_rev.py
+++ b/examples/optimize_poly_rev.py
@@ -11,7 +11,7 @@ import ctypes
 with open('loma_code/bigger_poly_rev.py') as f:
     _, lib = compiler.compile(f.read(),
                               target = 'c',
-                              output_filename = '_code/bigger_poly_rev.so')
+                              output_filename = '_code/bigger_poly_rev')
 
 f = lib.bigger_poly
 grad_f = lib.grad_bigger_poly

--- a/examples/raytrace_host.py
+++ b/examples/raytrace_host.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     with open('loma_code/raytrace.py') as f:
         structs, lib = compiler.compile(f.read(),
                                   target = 'c',
-                                  output_filename = '_code/raytrace.so')
+                                  output_filename = '_code/raytrace')
 
     w = 400
     h = 225

--- a/examples/single_pendulum_fwd.py
+++ b/examples/single_pendulum_fwd.py
@@ -11,7 +11,7 @@ import ctypes
 with open('loma_code/pendulum_fwd.py') as f:
     structs, lib = compiler.compile(f.read(),
                               target = 'c',
-                              output_filename = '_code/pendulum_fwd.so')
+                              output_filename = '_code/pendulum_fwd')
 dHdq = lib.dHdq
 dHdp = lib.dHdp
 PendulumConfig = structs['PendulumConfig']

--- a/examples/sum_array_host.py
+++ b/examples/sum_array_host.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     with open('loma_code/sum_array.py') as f:
         _, lib = compiler.compile(f.read(),
                                   target = 'c',
-                                  output_filename = '_code/sum_array.so')
+                                  output_filename = '_code/sum_array')
 
     py_arr = [1.0, 2.0, 3.0, 4.0, 5.0]
     arr = (ctypes.c_float * len(py_arr))(*py_arr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asdl==0.1.5
 attrs==23.2.0
 gpuctypes==0.3.0
-matplotlib==3.5.2
+# matplotlib==3.5.2  # is too old for my python 3.11
+matplotlib>=3.5.2
 numpy==1.23.5
 yapf==0.40.1


### PR DESCRIPTION
Now I understand how hard it is to enable cross-platform support. And I couldn't image the extra difficulty when you don't have a Windows machine.

First, I removed those ".so" from example code. They are already removed from hw test code. Before that, the example code sum_array just throws error because of some wrong paths. Now it works.

Here are the fixes on compile(), which generates confusing lib filenames. This update log is copied from the compile() docstring:
```python
"""UPDATE LOG:
1. General programming bug: output_filename : str = None 
    will cause a bug if we don't specify its value (though we never).
    It's better to have some concrete default value (e.g. gcc use a.out)
2. Windows path: it's better to distinguish what suffix -- [.o, .dll, etc.] to apppend
    to {output_filename}, which doesn't have a suffix.
    The original code at "# + .dll or + .so" messed up this suffix-free {output_filename}
    and thus messed up filenames we generate:
    on Windows, we created something like sum_array.so.dll
    on Linux, the lib is sum_array.so.so instead of sum_array.so
    We will just create different var for these strings to better clearify things.
    Use sum_array as example, we are likely to have these under _code/ on Windows
    - sum_array.dll
    - sum_array.exp
    - sum_array.lib
    - sum_array.o

FIXED & TESTED: c backend, Windows and Linux(Ubuntu)
FIXED (but probably work): ispc
cl_compile() hasn't been fixed
"""
```

Also, I provided a handy tool:
- tasks.json: it allow VSCode enthusiasts like me to easily launch VS developer console, which is necessary for running cl.exe, in VSCode integrated terminal.

Glad to help!